### PR TITLE
Fix setup.py not copying .py files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     license      = 'MIT',
     long_description_content_type = "text/markdown",
     long_description = documentation,
-    packages=find_packages(),
+    packages=find_packages(where="library/"),
     ext_modules  = cythonize(ext_modules, 
                             compiler_directives={'language_level' : "3"},
                             include_path=['library/MAS_library/',


### PR DESCRIPTION
A friend ran into a bug installing the library from PyPI where only the build `.so` files were copied into `MAS_library`, `Pk_library`, etc.

Without the argument, `find_packages()` returns an empty list, so the `.py` files in `library/*` never get copied (and the module members aren't accessible)

This fixes it as far as I can tell