### PR TITLE
patched LINK : fatal error LNK1181: cannot open input file 'm.lib'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ ext_modules = [
         ["library/MAS_library/MAS_library.pyx", "library/MAS_library/MAS_c.c"],
         extra_compile_args=extra_compile_args_omp,
         extra_link_args=extra_link_args,
-        libraries=["m"],
+        libraries=[],
     ),
     Extension(
         "Pk_library.Pk_library",
@@ -44,7 +44,7 @@ ext_modules = [
         ["library/smoothing_library/smoothing_library.pyx"],
         extra_compile_args=extra_compile_args_omp,
         extra_link_args=extra_link_args,
-        libraries=["m"],
+        libraries=[],
     ),
     Extension(
         "void_library.void_library",
@@ -54,7 +54,7 @@ ext_modules = [
         ],
         extra_compile_args=extra_compile_args_omp,
         extra_link_args=extra_link_args,
-        libraries=["m"],
+        libraries=[],
     ),
     Extension(
         "integration_library.integration_library",


### PR DESCRIPTION
The library "m.lib" doesn't need explicit linking for MSVC in versions >14