### PR TITLE
add PyTables dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "Cython<3.0.0", "numpy", "h5py", "hdf5plugin"]
+requires = ["setuptools", "Cython<3.0.0", "numpy", "h5py", "hdf5plugin", "tables"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ setup(
         "scipy",
         "hdf5plugin",
         "Cython<3.0.0",
+        "tables",
     ],
     package_dir={"": "library/"},
     py_modules=[


### PR DESCRIPTION
`readsnapHDF5.py` needs `PyTables`, but it isn't included as a requirement in `setup.py` or `pyproject.toml`, which may be confusing for users that need that functionality. (I ran into it when trying to import `HI_library`.) This PR just adds `tables` as a dependency. (If there's a specific reason why this hasn't been done already, feel free to close this PR.)