### PR TITLE
Count both total and highword particles in header.nall

### DIFF
--- a/library/readgadget.py
+++ b/library/readgadget.py
@@ -31,6 +31,11 @@ class header:
             self.redshift = f['Header'].attrs[u'Redshift']
             self.npart    = (f['Header'].attrs[u'NumPart_ThisFile']).astype(np.int64)
             self.nall     = (f['Header'].attrs[u'NumPart_Total']).astype(np.int64)
+            try:
+                self.nhigh = (f['Header'].attrs[u'NumPart_Total_HighWord']).astype(np.int64)
+                self.nall += (self.nhigh << np.int64(32))
+            except KeyError:
+                pass
             self.filenum  = int(f['Header'].attrs[u'NumFilesPerSnapshot'])
             self.massarr  = f['Header'].attrs[u'MassTable']
             self.boxsize  = f['Header'].attrs[u'BoxSize']


### PR DESCRIPTION
Counting the correct total number of particles `nall` is important for reading in particle properties from the snapshots using `read_block()`.

Currently `header.nall` only count particles in Gadget's header attribute `NumPart_Total`. This is correct for Gadget-4 in all cases, but only correct for Gadget-2 if the total number of particles $\leq2^{32}$. For Gadget-2, if the total number of particles exceeds that number, one need to also count `NumPart_Total_HighWord`. See, e.g., [here](https://www.tng-project.org/data/docs/specifications/)). Essentially, in such cases, `NumPart_Total` is the part modulo $2^{32}$ while `NumPart_Total_HighWord` is the total divided by $2^{32}$ rounding downwards.

I propose that we try to load that `NumPart_Total_HighWord` attribute and count the correct total number of particles if the attribute exists in the header. I have verified that this works as intended on our cluster.