### PR TITLE
Not forcing Cython version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "Cython<3.0.0", "numpy", "h5py", "hdf5plugin", "tables"]
+requires = ["setuptools", "Cython", "numpy", "h5py", "hdf5plugin", "tables"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Stop forcing Cython < 3.0.0